### PR TITLE
Updates AdGuard Public Resolvers Link

### DIFF
--- a/public_resolvers/index.html
+++ b/public_resolvers/index.html
@@ -1527,9 +1527,9 @@ See <a href="https://quad9.net/">https://quad9.net</a> and their <a href="https:
 </tr>
 <tr class="even">
 <td class="confluenceTd">Adguard</td>
-<td class="confluenceTd">Various, see <a href="https://adguard.com/en/blog/adguard-dns-announcement/">this AdGuard announcement</a></td>
+<td class="confluenceTd">Various, see <a href="https://adguard-dns.io/en/public-dns.html">the AdGuard website</a></td>
 <td class="confluenceTd">853</td>
-<td class="confluenceTd">Various, see <a href="https://adguard.com/en/blog/adguard-dns-announcement/">this AdGuard announcement/</a></td>
+<td class="confluenceTd">Various, see <a href="https://adguard-dns.io/en/public-dns.html">the AdGuard website/</a></td>
 <td class="confluenceTd">Not published</td>
 <td colspan="4" class="confluenceTd"><p><a href="https://adguard.com/en/adguard-dns/setup.html#instruction">https://adguard.com/en/adguard-dns/setup.html#instruction</a></p>
 <p><a href="https://adguard.com/en/privacy.html">https://adguard.com/en/privacy.html</a></p>
@@ -1623,7 +1623,7 @@ It has a different (stronger) privacy policy than the general Cloudflare DoH ser
 </tr>
 <tr class="even">
 <td class="confluenceTd">Adguard</td>
-<td class="confluenceTd">Various, see <a href="https://adguard.com/en/blog/adguard-dns-announcement/">this Adguard announcment</a></td>
+<td class="confluenceTd">Various, see <a href="https://adguard-dns.io/en/public-dns.html">the AdGuard website</a></td>
 <td colspan="6" class="confluenceTd">This service provides different end points with different filters (security, family, adult) so visit the website to select the end point with the filter you prefer.
 </td>
 </tr>
@@ -1650,7 +1650,7 @@ It has a different (stronger) privacy policy than the general Cloudflare DoH ser
 <p>Google also run a DoH endpoint at https://dns.google/resolve? using a
 proprietary JSON API.</p>
 <h2 id="dns-over-quic-doq">DNS-over-QUIC (DoQ)</h2>
-<p>AdGuard launched the first DoQ public resolver in 2020: <a href="https://adguard.com/en/blog/dns-over-quic.html">https://adguard.com/en/blog/dns-over-quic.html</a></p>
+<p>AdGuard launched the first DoQ public resolver in 2020: <a href="https://adguard-dns.io/en/blog/dns-over-quic.html">https://adguard-dns.io/en/blog/dns-over-quic.html</a></p>
 
 
 


### PR DESCRIPTION
Hey all!

I was linking your page on public resolvers on my blog and noticed that most of the AdGuard links were broken because they had changed their domain. This PR updates these links.

I wasn't sure whether contributions were welcome, so feel free to discard this PR if you want or if there's some build step that I'm unaware of. As long as the information is out there.

Have a nice day!