### PR TITLE
Fix typo in public resolvers page

### DIFF
--- a/public_resolvers/index.html
+++ b/public_resolvers/index.html
@@ -1590,9 +1590,9 @@ See <a href="https://quad9.net/">https://quad9.net</a> and their <a href="https:
 </tr>
 <tr class="even">
 <td class="confluenceTd">DNS4EU</td>
-<td class="confluenceTd"><p>Various see <a href="https://www.joindns4.eu/for-public#resolver-options">the DSN4EU website</a></p></td>
+<td class="confluenceTd"><p>Various see <a href="https://www.joindns4.eu/for-public#resolver-options">the DNS4EU website</a></p></td>
 <td class="confluenceTd">853</td>
-<td class="confluenceTd">Various see <a href="https://www.joindns4.eu/for-public#resolver-options">the DSN4EU website</td>
+<td class="confluenceTd">Various see <a href="https://www.joindns4.eu/for-public#resolver-options">the DNS4EU website</td>
 <td class="confluenceTd">Not published</td>
 <td colspan="4" class="confluenceTd"><p><a href="https://developers.google.com/speed/public-dns/docs/dns-over-tls">Privacy policy</a></p>
 <p>DNS4EU Public Service is dedicated to the citizens of the European Union. This service provides different end points with different filters (Protective, Child protective, Ad blocking) so visit the website to select the end point with the filter you prefer. NOTE: it also does DoH</a>.</p></td>


### PR DESCRIPTION
I believe it should be DNS4EU, not DSN4EU